### PR TITLE
feat: add frontend state management and type definitions

### DIFF
--- a/frontend/src/state/vehicle-store.ts
+++ b/frontend/src/state/vehicle-store.ts
@@ -1,0 +1,119 @@
+/**
+ * Zustand store for global vehicle state management.
+ *
+ * This store provides shared state across all frontend components:
+ * - VehicleEditor writes to `vehicle`
+ * - VehiclePreview reads `vehicle` and writes preview state
+ * - DropTestPanel reads `vehicle` and writes fitness history
+ * - EvolutionDashboard reads `vehicle.config` and writes evolution state
+ * - Layout reads all state for status indicators
+ */
+
+import { create } from 'zustand';
+import { DEFAULT_VEHICLE, VehicleType, GenerationResult, FitnessRecord } from '../types/vehicle';
+
+export interface AppState {
+  // ============================================================
+  // Vehicle Editing
+  // ============================================================
+
+  /** Current vehicle being edited */
+  vehicle: VehicleType;
+
+  /** Update the current vehicle (called by VehicleEditor) */
+  setVehicle: (vehicle: VehicleType) => void;
+
+  // ============================================================
+  // Preview State
+  // ============================================================
+
+  /** Whether a preview render is currently in progress */
+  previewLoading: boolean;
+
+  /** Base64-encoded preview image (null if not yet loaded) */
+  previewImage: string | null;
+
+  /** Set preview loading state */
+  setPreviewLoading: (loading: boolean) => void;
+
+  /** Set preview image (base64 string) */
+  setPreviewImage: (image: string | null) => void;
+
+  // ============================================================
+  // Fitness Evaluation
+  // ============================================================
+
+  /** History of all fitness evaluations from DropTestPanel */
+  fitnessHistory: FitnessRecord[];
+
+  /** Add a new fitness evaluation result */
+  addFitnessResult: (record: FitnessRecord) => void;
+
+  // ============================================================
+  // Evolution
+  // ============================================================
+
+  /** Whether the evolutionary algorithm is currently running */
+  evolutionRunning: boolean;
+
+  /** Set evolution running state */
+  setEvolutionRunning: (running: boolean) => void;
+
+  /** Results from each generation of the evolutionary algorithm */
+  generations: GenerationResult[];
+
+  /** Add a new generation result */
+  addGeneration: (generation: GenerationResult) => void;
+
+  /** Clear all generation history (e.g., when starting a new run) */
+  clearGenerations: () => void;
+}
+
+/**
+ * Global vehicle state store.
+ *
+ * Usage:
+ * ```tsx
+ * import { useVehicleStore } from './state/vehicle-store';
+ *
+ * function MyComponent() {
+ *   const vehicle = useVehicleStore((state) => state.vehicle);
+ *   const setVehicle = useVehicleStore((state) => state.setVehicle);
+ *   // ...
+ * }
+ * ```
+ */
+export const useVehicleStore = create<AppState>((set) => ({
+  // Initial vehicle state
+  vehicle: DEFAULT_VEHICLE,
+
+  setVehicle: (vehicle) => set({ vehicle }),
+
+  // Initial preview state
+  previewLoading: false,
+  previewImage: null,
+
+  setPreviewLoading: (previewLoading) => set({ previewLoading }),
+  setPreviewImage: (previewImage) => set({ previewImage }),
+
+  // Initial fitness state
+  fitnessHistory: [],
+
+  addFitnessResult: (record) =>
+    set((state) => ({
+      fitnessHistory: [...state.fitnessHistory, record],
+    })),
+
+  // Initial evolution state
+  evolutionRunning: false,
+  generations: [],
+
+  setEvolutionRunning: (evolutionRunning) => set({ evolutionRunning }),
+
+  addGeneration: (generation) =>
+    set((state) => ({
+      generations: [...state.generations, generation],
+    })),
+
+  clearGenerations: () => set({ generations: [] }),
+}));

--- a/frontend/src/types/vehicle.ts
+++ b/frontend/src/types/vehicle.ts
@@ -1,0 +1,70 @@
+/**
+ * Type definitions for vehicle geometry and state.
+ * These types must match the backend Pydantic models exactly.
+ * Source: src/glider/serving/schema.py
+ */
+
+/**
+ * VehicleType represents the complete vehicle geometry and configuration.
+ * Must match the Pydantic VehicleType model field-for-field.
+ */
+export interface VehicleType {
+  /** 3D vertex coordinates as [x, y, z] arrays */
+  vertices: number[][] | null;
+  /** Triangle face indices referencing vertices array */
+  faces: number[][] | null;
+  /** Maximum wing dimension in meters */
+  max_dim_m: number | null;
+  /** Total vehicle mass in kilograms (overrides density calculation if set) */
+  mass_kg: number | null;
+  /** Euler angles [roll, pitch, yaw] for initial orientation */
+  orientation: number[] | null;
+  /** Wing material density (kg/m³) - used if mass_kg is null */
+  wing_density: number | null;
+  /** Whether to include a pilot body in the simulation */
+  pilot: boolean;
+}
+
+/**
+ * Default vehicle configuration.
+ * Sources:
+ * - src/glider/vehicle.py lines 57-61
+ * - src/glider/constants.py lines 15-17
+ */
+export const DEFAULT_VEHICLE: VehicleType = {
+  vertices: null,
+  faces: null,
+  max_dim_m: 4.5, // DEFAULT_MAX_WING_DIMENSION_M
+  mass_kg: null,
+  orientation: [0, 0, 0],
+  wing_density: 0.4, // WING_DENSITY
+  pilot: false,
+};
+
+/**
+ * Result from a single generation in the evolutionary algorithm.
+ */
+export interface GenerationResult {
+  /** Generation number (0-indexed) */
+  generation: number;
+  /** Fitness score of the best individual in this generation */
+  bestFitness: number;
+  /** Average fitness across the entire population */
+  avgFitness: number;
+  /** The best-performing vehicle in this generation */
+  bestVehicle: VehicleType;
+  /** Fitness scores for all individuals (for histogram rendering) */
+  populationFitness: number[];
+}
+
+/**
+ * Record of a single fitness evaluation.
+ */
+export interface FitnessRecord {
+  /** Vehicle that was evaluated */
+  vehicle: VehicleType;
+  /** Fitness score achieved */
+  score: number;
+  /** Unix timestamp (milliseconds) when evaluation completed */
+  timestamp: number;
+}


### PR DESCRIPTION
## Summary

Creates shared state management and type definitions for the frontend architecture.

## Changes

- Create VehicleType interface matching backend Pydantic schema
- Add GenerationResult and FitnessRecord types
- Implement Zustand store for global app state
- Define component contracts for #3–#7 integration

## Architecture Decisions

- **Zustand over React Context**: Better async handling and performance
- **Backend schema matching**: VehicleType mirrors Pydantic model exactly
- **Single source of truth**: All components share the same store

Closes #8

---

Generated with [Claude Code](https://claude.ai/code)