### PR TITLE
fix: add ruff to dev dependencies, remove flake8 and black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,7 @@ jupyter = "^1.0.0"
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"
 mypy = "^0.910"
-flake8 = "^3.9.2"
-black = "^21.9b0"
+ruff = ">=0.4.0"
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
## Summary

Fixes CI by adding ruff to dev dependencies and removing flake8 and black since ruff replaces both.

## Changes

- Add ruff>=0.4.0 to dev dependencies
- Remove flake8 and black as ruff replaces both
- Existing ruff configuration is compatible with ruff>=0.4.0

Fixes #15

Generated with [Claude Code](https://claude.ai/code)