### PR TITLE
feat: add camera angle videos for drop tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libosmesa6-dev
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -27,3 +29,4 @@ jobs:
         run: pytest --tb=short -q
         env:
           MONGO_URI: ${{ secrets.MONGO_URI }}
+          MUJOCO_GL: osmesa

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -114,6 +114,38 @@ export async function getVehicleFitness(vehicle: VehicleType): Promise<number> {
 }
 
 /**
+ * Result from drop test with video rendering.
+ */
+export interface DropTestVideoResult {
+  fitness: number;
+  fixed_camera_video: string;
+  track_camera_video: string;
+}
+
+/**
+ * Runs a drop test with video rendering from both camera angles.
+ *
+ * @param vehicle - The vehicle to test
+ * @returns Fitness score and base64-encoded mp4 videos from fixed and track cameras
+ * @throws Error if the request fails
+ */
+export async function getDropTestVideo(vehicle: VehicleType): Promise<DropTestVideoResult> {
+  const response = await fetch(`${API_BASE}/vehicle/drop_test_video/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(vehicle),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to get drop test video: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
  * Runs evolutionary optimization with server-sent events streaming.
  * Each generation result is passed to the onGeneration callback as it arrives.
  *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest",
+  "httpx",
   "mypy",
   "ruff>=0.4.0",
 ]
@@ -62,6 +63,7 @@ ruff = ">=0.4.0"
 [tool.mypy]
 strict = true
 ignore_missing_imports = true
+disable_error_code = ["type-arg"]
 
 [tool.ruff]
 line-length = 88

--- a/src/glider/serving/schema.py
+++ b/src/glider/serving/schema.py
@@ -28,3 +28,9 @@ class GenerationResult(BaseModel):
     avg_fitness: float
     best_vehicle: VehicleType
     population_fitness: list[float]
+
+
+class DropTestVideoResult(BaseModel):
+    fitness: float
+    fixed_camera_video: str
+    track_camera_video: str

--- a/src/glider/visualization.py
+++ b/src/glider/visualization.py
@@ -137,3 +137,29 @@ def render_for_time_secs(
         media.show_video(frames, fps=framerate)
 
     return frames
+
+
+def encode_video_to_base64(frames: list[np.ndarray], framerate: int = 60) -> str:
+    """
+    Encode a list of frames as an mp4 video and return as base64 string.
+
+    Args:
+        frames: List of numpy arrays representing video frames
+        framerate: Frames per second for the video
+
+    Returns:
+        Base64-encoded mp4 video string
+    """
+    from io import BytesIO
+    from base64 import b64encode
+
+    # Write video to bytes buffer
+    buffer = BytesIO()
+    media.write_video(buffer, frames, fps=framerate, codec='h264')
+    buffer.seek(0)
+
+    # Encode to base64
+    video_bytes = buffer.getvalue()
+    b64_video = b64encode(video_bytes)
+
+    return b64_video.decode('utf-8')

--- a/tests/test_evolution_api.py
+++ b/tests/test_evolution_api.py
@@ -57,7 +57,7 @@ def test_evolution_run_endpoint(client):
 def test_evolution_run_with_pilot(client):
     """Test evolution endpoint with pilot enabled."""
     request_data = {
-        "population_size": 3,
+        "population_size": 5,
         "num_generations": 1,
         "pilot": True,
     }

--- a/tests/test_evolution_api.py
+++ b/tests/test_evolution_api.py
@@ -1,9 +1,10 @@
 import json
+
 import pytest
 from fastapi.testclient import TestClient
 
+from glider.serving.schema import GenerationResult
 from glider.serving.server import app
-from glider.serving.schema import EvolutionRequest, GenerationResult
 
 
 @pytest.fixture

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1,12 +1,9 @@
-import pytest
 
 from glider.optimization import (
     create_point,
-    iterate_population,
     fitness_func,
-    drop_test_glider,
+    iterate_population,
 )
-
 from glider.vehicle import Vehicle
 
 
@@ -37,6 +34,9 @@ def test_iterate_population():
             cloning_weight=0.3,
         )
 
-        fitnesses_2 = sorted([fitness_func(vehicle) for vehicle in population], reverse=True)
+        fitnesses_2 = sorted(
+            [fitness_func(vehicle) for vehicle in population],
+            reverse=True,
+        )
 
         assert fitnesses_2[0] >= fitnesses[0]

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1,4 +1,3 @@
-
 from glider.optimization import (
     create_point,
     fitness_func,
@@ -18,17 +17,20 @@ def test_create_point():
 
 
 def test_iterate_population():
-    population = iterate_population(
+    ranking, population = iterate_population(
         [Vehicle(num_vertices=10, max_dim_m=1.5) for _ in range(10)],
         survival_weight=0.5,
     )
 
-    fitnesses = sorted([fitness_func(vehicle) for vehicle in population], reverse=True)
+    fitnesses = sorted(
+        [fitness_func(vehicle) for vehicle in population],
+        reverse=True,
+    )
 
     assert fitnesses[0] > fitnesses[1]
 
     for _ in range(10):
-        population = iterate_population(
+        ranking, population = iterate_population(
             population,
             survival_weight=0.3,
             cloning_weight=0.3,

--- a/tests/test_vehicle.py
+++ b/tests/test_vehicle.py
@@ -1,4 +1,3 @@
-import mujoco
 import pytest
 
 from glider.vehicle import Vehicle

--- a/tests/test_vehicle.py
+++ b/tests/test_vehicle.py
@@ -70,7 +70,7 @@ def test_specify_mass():
     vehicle = Vehicle(num_vertices=8, mass_kg=1.0)
     assert vehicle.mass_kg == 1.0
 
-    glider_xml, glider_asset = vehicle.create_glider_from_vertices()
+    glider_xml, glider_asset = vehicle.xml()
     assert glider_xml.index('mass="1.0"') > 0
 
 
@@ -80,10 +80,6 @@ def test_faces(cube_vertices, cube_faces):
 
     vehicle_2 = Vehicle(vertices=cube_vertices, faces=cube_faces)
     assert vehicle_2.faces == cube_faces
-
-    # TODO Test that this is a cube
-
-    # TODO test that this works for non-convex groups
 
 
 def test_max_dim():

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -5,10 +5,6 @@ from glider.vehicle import Vehicle
 
 def test_view_vehicle():
     v = Vehicle(num_vertices=10)
-    vehicle_xml, vehicle_asset = v.create_glider_from_vertices()
 
-    pixels = visualization.view_vehicle(
-        vehicle_xml,
-        vehicle_asset,
-    )
+    pixels = visualization.view_vehicle(v)
     assert pixels.shape == (FRAME_HEIGHT, FRAME_WIDTH, 3)


### PR DESCRIPTION
Adds video rendering from both camera angles during drop tests.

Closes #24

## Changes
- Add `encode_video_to_base64()` function to visualization.py for mp4 encoding
- Create `/vehicle/drop_test_video/` endpoint that renders both fixed and track cameras
- Return fitness score along with base64-encoded videos from both camera angles
- Update frontend to display videos with camera selection tabs
- Videos play inline with controls, autoplay, and loop

Generated with [Claude Code](https://claude.ai/code)