### PR TITLE
feat: extend API schema for shape types

### DIFF
--- a/src/glider/serving/factory.py
+++ b/src/glider/serving/factory.py
@@ -26,11 +26,21 @@ def vehicle_from_schema(v: VehicleType) -> Vehicle:
                 max_dim_m if max_dim_m is not None else DEFAULT_MAX_WING_DIMENSION_M
             ),
         )
+        max_dim = (
+            v.max_dim_m
+            if v.max_dim_m is not None
+            else DEFAULT_MAX_WING_DIMENSION_M
+        )
+        wing_density = (
+            v.wing_density
+            if v.wing_density is not None
+            else WING_DENSITY
+        )
         return Vehicle(
-            max_dim_m=v.max_dim_m,
+            max_dim_m=max_dim,
             mass_kg=v.mass_kg,
             orientation=v.orientation or [0.0, 0.0, 0.0],
-            wing_density=v.wing_density if v.wing_density is not None else WING_DENSITY,
+            wing_density=wing_density,
             pilot=v.pilot,
             shape_config=shape_config,
         )

--- a/src/glider/serving/factory.py
+++ b/src/glider/serving/factory.py
@@ -22,7 +22,9 @@ def vehicle_from_schema(v: VehicleType) -> Vehicle:
 
         shape_config = PointCloudConfig(
             vertices=vertices or [],
-            max_dim_m=max_dim_m if max_dim_m is not None else DEFAULT_MAX_WING_DIMENSION_M,
+            max_dim_m=(
+                max_dim_m if max_dim_m is not None else DEFAULT_MAX_WING_DIMENSION_M
+            ),
         )
         return Vehicle(
             max_dim_m=v.max_dim_m,

--- a/src/glider/serving/factory.py
+++ b/src/glider/serving/factory.py
@@ -1,0 +1,38 @@
+from glider.constants import DEFAULT_MAX_WING_DIMENSION_M, WING_DENSITY
+from glider.shapes import PointCloudConfig
+from glider.vehicle import Vehicle
+
+from .schema import VehicleType
+
+
+def vehicle_from_schema(v: VehicleType) -> Vehicle:
+    """Construct a Vehicle from a VehicleType schema object.
+
+    Raises ValueError for unknown shape_type values.
+    """
+    shape_type = v.shape_type
+
+    if shape_type == "point_cloud":
+        if v.shape_params is not None:
+            vertices = v.shape_params.get("vertices", v.vertices)
+            max_dim_m = v.shape_params.get("max_dim_m", v.max_dim_m)
+        else:
+            vertices = v.vertices
+            max_dim_m = v.max_dim_m
+
+        shape_config = PointCloudConfig(
+            vertices=vertices or [],
+            max_dim_m=max_dim_m if max_dim_m is not None else DEFAULT_MAX_WING_DIMENSION_M,
+        )
+        return Vehicle(
+            max_dim_m=v.max_dim_m,
+            mass_kg=v.mass_kg,
+            orientation=v.orientation or [0.0, 0.0, 0.0],
+            wing_density=v.wing_density if v.wing_density is not None else WING_DENSITY,
+            pilot=v.pilot,
+            shape_config=shape_config,
+        )
+
+    raise ValueError(
+        f"Unknown shape_type: {shape_type!r}. Supported types: 'point_cloud'."
+    )

--- a/src/glider/serving/schema.py
+++ b/src/glider/serving/schema.py
@@ -9,6 +9,10 @@ class VehicleType(BaseModel):
     orientation: list[float] | None
     wing_density: float | None
     pilot: bool = False
+    shape_type: str = "point_cloud"
+    naca_params: dict | None = None
+    parametric_params: dict | None = None
+    shape_params: dict | None = None
 
 
 class EvolutionRequest(BaseModel):

--- a/src/glider/serving/server.py
+++ b/src/glider/serving/server.py
@@ -10,6 +10,7 @@ from PIL import Image
 from glider import optimization, vehicle, visualization
 from glider.constants import WING_DENSITY
 
+from .factory import vehicle_from_schema
 from .schema import (
     DropTestTrajectoryResult,
     DropTestVideoResult,
@@ -56,13 +57,13 @@ async def create_vehicle() -> VehicleType:
 
 @app.post("/vehicle/drop_test/")
 async def drop_test_vehicle(v: VehicleType) -> str:
-    test_vehicle = vehicle.Vehicle(**v.model_dump())
+    test_vehicle = vehicle_from_schema(v)
     return optimization.drop_test_glider(test_vehicle)
 
 
 @app.post("/vehicle/view/")
 async def view_vehicle(v: VehicleType) -> dict[str, str]:
-    test_vehicle = vehicle.Vehicle(**v.model_dump())
+    test_vehicle = vehicle_from_schema(v)
     buf = BytesIO()
     Image.fromarray(
         visualization.view_vehicle(test_vehicle)
@@ -73,7 +74,7 @@ async def view_vehicle(v: VehicleType) -> dict[str, str]:
 
 @app.post("/vehicle/fitness/")
 async def vehicle_fitness(v: VehicleType) -> float:
-    test_vehicle = vehicle.Vehicle(**v.model_dump())
+    test_vehicle = vehicle_from_schema(v)
     return optimization.fitness_func(test_vehicle)
 
 
@@ -84,7 +85,7 @@ async def drop_test_video(
     """Run a drop test and return videos from both camera angles."""
     import mujoco
 
-    test_vehicle = vehicle.Vehicle(**v.model_dump())
+    test_vehicle = vehicle_from_schema(v)
 
     world_xml = optimization.drop_test_glider(
         test_vehicle, height=optimization.DROP_TEST_HEIGHT
@@ -124,7 +125,7 @@ async def drop_test_trajectory(
     sample_rate: int = 60,
 ) -> DropTestTrajectoryResult:
     """Run a drop test and return per-frame trajectory data plus fitness."""
-    test_vehicle = vehicle.Vehicle(**v.model_dump())
+    test_vehicle = vehicle_from_schema(v)
 
     raw_frames, fitness = optimization.simulate_trajectory(
         test_vehicle, sample_rate=sample_rate

--- a/src/glider/vehicle.py
+++ b/src/glider/vehicle.py
@@ -208,6 +208,26 @@ class Vehicle:
         asset_xml = self.get_wing_asset()
         return body_xml, asset_xml
 
+    def to_schema(self) -> dict:
+        """Serialize this Vehicle to a dict compatible with VehicleType schema."""
+        return {
+            "vertices": self.vertices,
+            "faces": self.faces,
+            "max_dim_m": self.max_dim_m,
+            "mass_kg": self.mass_kg,
+            "orientation": self.orientation,
+            "wing_density": self.wing_density,
+            "pilot": self.pilot,
+            "shape_type": "point_cloud",
+            "shape_params": (
+                self.shape_config.params_dict()
+                if self.shape_config is not None
+                else None
+            ),
+            "naca_params": None,
+            "parametric_params": None,
+        }
+
     def show(self) -> None:
         media.show_image(visualization.view_vehicle(self))
 


### PR DESCRIPTION
Extends VehicleType schema with shape_type field and adds vehicle_from_schema() factory.

Closes #27